### PR TITLE
allow urand to run for a single injection rate

### DIFF
--- a/bin/urand/run_urand.py
+++ b/bin/urand/run_urand.py
@@ -208,7 +208,10 @@ def begin_all_sims(config):
     str(config.runRateStep))
 
     # Initialze the latencies.
-    injectionRates = np.arange(config.runRateMin, config.runRateMax, config.runRateStep)
+    if config.runRateMin == config.runRateMax:
+        injectionRates = [config.runRateMin]
+    else:
+        injectionRates = np.arange(config.runRateMin, config.runRateMax, config.runRateStep)
     injectionRates = [round(elem, 4) for elem in injectionRates]
     latenciesFlit = -np.ones((len(injectionRates), config.restarts))
     latenciesPacket = -np.ones((len(injectionRates), config.restarts))


### PR DESCRIPTION
I find it useful to allow urand to run simulations for a single injection rate (i.e. runRateMin = runRateMax). The prime implementation uses np.arange(start,end,step) which doesn't accept start = end. 