### PR TITLE
homogeneous 3d torus routing algorithm (XYZ, ZXYZ)

### DIFF
--- a/simulator/src/model/router/routings/XYZRouting.cpp
+++ b/simulator/src/model/router/routings/XYZRouting.cpp
@@ -54,15 +54,13 @@ int XYZRouting::route(int src_node_id, int dst_node_id)
     }
     else if (globalResources.routingCircular == true)
     {
-        // TODO: implementation for 3D mesh
-        assert(globalResources.zPositions.size() == 1); // only accept 1~2D model, need to be removed when 3D mesh is implemented
-
+        Vec3D<int> src_coord = globalResources.norm_to_coord[src_pos];
         Vec3D<float> inner_len = (src_pos - dst_pos).abs();
         Vec3D<float> outer_len;
 
-        // this kind of calculation only suitable for 2D mesh and ring, for 3D it is required to know the step value for x and y of each layer
-        outer_len.x = 1. - inner_len.x + globalResources.xPositions[1];
-        outer_len.y = 1. - inner_len.y + globalResources.yPositions[1];
+        outer_len.x = 1. - inner_len.x + globalResources.x_step[src_coord.z];
+        outer_len.y = 1. - inner_len.y + globalResources.y_step[src_coord.z];
+        outer_len.z = 1. - inner_len.z + globalResources.z_step;
 
         if (dst_pos == src_pos)
             con_pos = src_node.getConPosOfDir(DIR::Local);
@@ -84,7 +82,15 @@ int XYZRouting::route(int src_node_id, int dst_node_id)
             con_pos = src_node.getConPosOfDir(DIR::North);
         else if ((dst_pos.y > src_pos.y) && (inner_len.y >= outer_len.y))
             con_pos = src_node.getConPosOfDir(DIR::South);
-
+        // z-axis
+        else if ((dst_pos.z < src_pos.z) && (inner_len.z <= outer_len.z))
+            con_pos = src_node.getConPosOfDir(DIR::Down);
+        else if ((dst_pos.z < src_pos.z) && (inner_len.z >= outer_len.z))
+            con_pos = src_node.getConPosOfDir(DIR::Up);
+        else if ((dst_pos.z > src_pos.z) && (inner_len.z <= outer_len.z))
+            con_pos = src_node.getConPosOfDir(DIR::Up);
+        else if ((dst_pos.z > src_pos.z) && (inner_len.z >= outer_len.z))
+            con_pos = src_node.getConPosOfDir(DIR::Down);
     }
 
     return con_pos;

--- a/simulator/src/model/router/routings/ZXYZRouting.cpp
+++ b/simulator/src/model/router/routings/ZXYZRouting.cpp
@@ -28,29 +28,75 @@ int ZXYZRouting::route(int src_node_id, int dst_node_id)
     Vec3D<float> dst_pos = globalResources.nodes.at(dst_node_id).pos;
     int con_pos = -1;
 
-    if (dst_pos==src_pos) {
-        con_pos = src_node.getConPosOfDir(DIR::Local);
-    } else if (dst_pos.z == .5 && src_pos.z == .5){
-        con_pos = src_node.getConPosOfDir(DIR::Down);
+    if (!globalResources.routingCircular)
+    {
+        if (dst_pos == src_pos)
+            con_pos = src_node.getConPosOfDir(DIR::Local);
+        else if (dst_pos.z == .5 && src_pos.z == .5)
+            con_pos = src_node.getConPosOfDir(DIR::Down);
+        else if (dst_pos.z < src_pos.z)
+            con_pos = src_node.getConPosOfDir(DIR::Down);
+        else if (dst_pos.z >= src_pos.z)
+        {
+            if (dst_pos.x < src_pos.x)
+                con_pos = src_node.getConPosOfDir(DIR::West);
+            else if (dst_pos.x > src_pos.x)
+                con_pos = src_node.getConPosOfDir(DIR::East);
+            else if (dst_pos.y < src_pos.y)
+                con_pos = src_node.getConPosOfDir(DIR::South);
+            else if (dst_pos.y > src_pos.y)
+                con_pos = src_node.getConPosOfDir(DIR::North);
+            else
+                con_pos = src_node.getConPosOfDir(DIR::Up);
+        }
     }
-    else if (dst_pos.z<src_pos.z) {
-        con_pos = src_node.getConPosOfDir(DIR::Down);
-    }
-    else if (dst_pos.z>=src_pos.z) {
-        if (dst_pos.x<src_pos.x) {
-            con_pos = src_node.getConPosOfDir(DIR::West);
-        }
-        else if (dst_pos.x>src_pos.x) {
-            con_pos = src_node.getConPosOfDir(DIR::East);
-        }
-        else if (dst_pos.y<src_pos.y) {
-            con_pos = src_node.getConPosOfDir(DIR::South);
-        }
-        else if (dst_pos.y>src_pos.y) {
-            con_pos = src_node.getConPosOfDir(DIR::North);
-        }
-        else
+    else
+    {
+        Vec3D<int> src_coord = globalResources.norm_to_coord[src_pos];
+        Vec3D<float> inner_len = (src_pos - dst_pos).abs();
+        Vec3D<float> outer_len;
+
+        outer_len.x = 1. - inner_len.x + globalResources.x_step[src_coord.z];
+        outer_len.y = 1. - inner_len.y + globalResources.y_step[src_coord.z];
+        outer_len.z = 1. - inner_len.z + globalResources.z_step;
+
+        if (dst_pos == src_pos)
+            con_pos = src_node.getConPosOfDir(DIR::Local);
+        else if (dst_pos.z == .5 && src_pos.z == .5)
+            con_pos = src_node.getConPosOfDir(DIR::Down);
+        //  z-axis
+        else if ((dst_pos.z < src_pos.z) && (inner_len.z <= outer_len.z))
+            con_pos = src_node.getConPosOfDir(DIR::Down);
+        else if ((dst_pos.z < src_pos.z) && (inner_len.z >= outer_len.z))
             con_pos = src_node.getConPosOfDir(DIR::Up);
+        else if (dst_pos.z >= src_pos.z)
+        {
+            // x-axis
+            if ((dst_pos.x < src_pos.x) && (inner_len.x <= outer_len.x))
+                con_pos = src_node.getConPosOfDir(DIR::West);
+            else if ((dst_pos.x < src_pos.x) && (inner_len.x >= outer_len.x))
+                con_pos = src_node.getConPosOfDir(DIR::East);
+            else if ((dst_pos.x > src_pos.x) && (inner_len.x <= outer_len.x))
+                con_pos = src_node.getConPosOfDir(DIR::East);
+            else if ((dst_pos.x > src_pos.x) && (inner_len.x >= outer_len.x))
+                con_pos = src_node.getConPosOfDir(DIR::West);
+            // y-axis
+            else if ((dst_pos.y < src_pos.y) && (inner_len.y <= outer_len.y))
+                con_pos = src_node.getConPosOfDir(DIR::South);
+            else if ((dst_pos.y < src_pos.y) && (inner_len.y >= outer_len.y))
+                con_pos = src_node.getConPosOfDir(DIR::North);
+            else if ((dst_pos.y > src_pos.y) && (inner_len.y <= outer_len.y))
+                con_pos = src_node.getConPosOfDir(DIR::North);
+            else if ((dst_pos.y > src_pos.y) && (inner_len.y >= outer_len.y))
+                con_pos = src_node.getConPosOfDir(DIR::South);
+            //  z-axis
+            else if ((dst_pos.z > src_pos.z) && (inner_len.z <= outer_len.z))
+                con_pos = src_node.getConPosOfDir(DIR::Up);
+            else if ((dst_pos.z > src_pos.z) && (inner_len.z >= outer_len.z))
+                con_pos = src_node.getConPosOfDir(DIR::Down);
+            else
+                con_pos = src_node.getConPosOfDir(DIR::Up);
+        }
     }
 
     return con_pos;

--- a/simulator/src/model/traffic/netrace/NetracePool.cpp
+++ b/simulator/src/model/traffic/netrace/NetracePool.cpp
@@ -27,8 +27,7 @@ NetracePool::NetracePool(sc_module_name nm)
 {
     cout << endl;
     cout << "Running in Netrace Benchmark mode." << endl;
-    cout << "  This mode has limited functionality. It can only be run with a 8x4x2 NoC or on a single layer of a 8x8x2 NoC" << endl;
-    cout << "  The mapping is changed in GlobalsResources.cpp, varibles netraceNodeToTask and netraceTaskToNode" << endl;
+    cout << "  The minimum total node count of the NoC must be the number of netrace simulated nodes." << endl;
     SC_THREAD(thread);
 }
 
@@ -115,13 +114,11 @@ void NetracePool::thread() {
                         ntnetrace.nt_print_packet(new_node->packet);
                     }
                     int src = static_cast<int>(trace_packet->src);
-                    if (!globalResources.netrace2Dor3Dmode && src >= 32)
-                        src += 32; // bring to 2nd layer
                     ProcessingElementVC* pe = (ProcessingElementVC*) processingElements.at(src);
                     pe->ntInject.push(std::make_pair(*new_node, new_node->cycle));
                 } else {
                     // Add to waiting queue
-                    ProcessingElementVC* pe = (ProcessingElementVC*) processingElements.at(trace_packet->src%48);
+                    ProcessingElementVC* pe = (ProcessingElementVC*) processingElements.at(trace_packet->src);
                     pe->ntWaiting.push(std::make_pair(*new_node, new_node->cycle));
                 }
                 // Get another packet from trace

--- a/simulator/src/utils/GlobalResources.cpp
+++ b/simulator/src/utils/GlobalResources.cpp
@@ -344,18 +344,6 @@ void GlobalResources::readNoCLayout(const std::string &nocPath)
                 norm_to_coord[temp_norm] = temp_coord;
             }
 
-    readNodeTypes(noc_node);
-    readNodes(noc_node);
-    readConnections(noc_node);
-    if (!RoutingTable_mode)
-    {
-        fillDirInfoOfNodeConn();
-    }
-    else
-    {
-        fillDirInfoOfNodeConn_DM();
-    }
-
 #ifdef ENABLE_NETRACE
     int temp_z = noc_node.child("abstract").child("z").attribute("value").as_int();
     std::vector<int> temp_xs;
@@ -369,12 +357,12 @@ void GlobalResources::readNoCLayout(const std::string &nocPath)
     while (iss >> temp)
         temp_ys.push_back(temp);
     int node_count = 0;
-    for(int i = 0; i < temp_z; i++)
+    for (int i = 0; i < temp_z; i++)
         node_count += (temp_xs[i] * temp_ys[i]);
 
     // make sure node_count always larger equal than 64, because netrace simulates 64 nodes
     // this line is to make it compatible for old simulation (old network.xml do not have xs, ys & z values.)
-    node_count = (node_count > 64)? node_count : 64;
+    node_count = (node_count > 64) ? node_count : 64;
 
     for (int i = 0; i < node_count; ++i)
     {
@@ -382,6 +370,18 @@ void GlobalResources::readNoCLayout(const std::string &nocPath)
         netraceTaskToNode.insert(std::pair<nodeID_t, int>(i, i + node_count));
     }
 #endif
+
+    readNodeTypes(noc_node);
+    readNodes(noc_node);
+    readConnections(noc_node);
+    if (!RoutingTable_mode)
+    {
+        fillDirInfoOfNodeConn();
+    }
+    else
+    {
+        fillDirInfoOfNodeConn_DM();
+    }
 }
 
 void GlobalResources::readNodeTypes(const pugi::xml_node &noc_node)

--- a/simulator/src/utils/GlobalResources.cpp
+++ b/simulator/src/utils/GlobalResources.cpp
@@ -25,39 +25,45 @@
 #include <iomanip>
 
 GlobalResources::GlobalResources()
-        :
-        simulation_time(0),
-        outputToFile(false),
-        activateFlitTracing(false),
-        routingVerticalThreshold(1.0),
-        Vdd(1.0),
-        isUniform(false),
-        numberOfTrafficTypes(0),
-        synthetic_start_measurement_time(-1)
+    : simulation_time(0),
+      outputToFile(false),
+      activateFlitTracing(false),
+      routingVerticalThreshold(1.0),
+      Vdd(1.0),
+      isUniform(false),
+      numberOfTrafficTypes(0),
+      synthetic_start_measurement_time(-1)
 {
     rand = new std::mt19937_64();
     auto seed = std::random_device{}();
     rand->seed(seed);
     rd_seed = seed;
 #ifdef ENABLE_NETRACE
-    for (int i = 0; i < 64; ++i) {
-        if (netrace2Dor3Dmode){
-            netraceNodeToTask.insert(std::pair<nodeID_t, int>(i+128, i));
-            netraceTaskToNode.insert(std::pair<int, nodeID_t>(i, i+128));
-        } else{
-            if (i<32){
-                netraceNodeToTask.insert(std::pair<nodeID_t, int>(i+128, i));
-                netraceTaskToNode.insert(std::pair<int, nodeID_t>(i, i+128));
-            } else {
-                netraceNodeToTask.insert(std::pair<nodeID_t, int>(i+128+64, i));
-                netraceTaskToNode.insert(std::pair<int, nodeID_t>(i, i+128+64));
+    for (int i = 0; i < 64; ++i)
+    {
+        if (netrace2Dor3Dmode)
+        {
+            netraceNodeToTask.insert(std::pair<nodeID_t, int>(i + 128, i));
+            netraceTaskToNode.insert(std::pair<int, nodeID_t>(i, i + 128));
+        }
+        else
+        {
+            if (i < 32)
+            {
+                netraceNodeToTask.insert(std::pair<nodeID_t, int>(i + 128, i));
+                netraceTaskToNode.insert(std::pair<int, nodeID_t>(i, i + 128));
+            }
+            else
+            {
+                netraceNodeToTask.insert(std::pair<nodeID_t, int>(i + 128 + 64, i));
+                netraceTaskToNode.insert(std::pair<int, nodeID_t>(i, i + 128 + 64));
             }
         }
     }
 #endif
 }
 
-GlobalResources& GlobalResources::getInstance()
+GlobalResources &GlobalResources::getInstance()
 {
     static GlobalResources instance;
     return instance;
@@ -75,76 +81,82 @@ float GlobalResources::getRandomFloatBetween(float min, float max)
     return dis(*rand);
 }
 
-void GlobalResources::readAttributeIfExists(pugi::xml_node node, const char* child, const char* attribute, int& var)
+void GlobalResources::readAttributeIfExists(pugi::xml_node node, const char *child, const char *attribute, int &var)
 {
     readAttributeIfExists(node.child(child), attribute, var);
 }
 
-void GlobalResources::readAttributeIfExists(pugi::xml_node node, const char* attribute, int& var)
+void GlobalResources::readAttributeIfExists(pugi::xml_node node, const char *attribute, int &var)
 {
-    if (!node.attribute(attribute).empty()) {
+    if (!node.attribute(attribute).empty())
+    {
         var = node.attribute(attribute).as_int();
     }
 }
 
-int GlobalResources::readRequiredIntAttribute(pugi::xml_node node, const char* child, const char* attribute)
+int GlobalResources::readRequiredIntAttribute(pugi::xml_node node, const char *child, const char *attribute)
 {
     return readRequiredIntAttribute(node.child(child), attribute);
 }
 
-int GlobalResources::readRequiredIntAttribute(pugi::xml_node node, const char* attribute)
+int GlobalResources::readRequiredIntAttribute(pugi::xml_node node, const char *attribute)
 {
-    if (node.attribute(attribute).empty()) {
+    if (node.attribute(attribute).empty())
+    {
         FATAL("Can not read node:" << node.path() << " " << attribute);
     }
     return node.attribute(attribute).as_int();
 }
 
-float GlobalResources::readRequiredFloatAttribute(pugi::xml_node node, const char* child, const char* attribute)
+float GlobalResources::readRequiredFloatAttribute(pugi::xml_node node, const char *child, const char *attribute)
 {
     return readRequiredFloatAttribute(node.child(child), attribute);
 }
 
-float GlobalResources::readRequiredFloatAttribute(pugi::xml_node node, const char* attribute)
+float GlobalResources::readRequiredFloatAttribute(pugi::xml_node node, const char *attribute)
 {
-    if (node.attribute(attribute).empty()) {
+    if (node.attribute(attribute).empty())
+    {
         FATAL("Can not read node:" << node.path() << " " << attribute);
     }
     return node.attribute(attribute).as_float();
 }
 
 std::string
-GlobalResources::readRequiredStringAttribute(pugi::xml_node node, const char* child, const char* attribute)
+GlobalResources::readRequiredStringAttribute(pugi::xml_node node, const char *child, const char *attribute)
 {
     return readRequiredStringAttribute(node.child(child), attribute);
 }
 
-std::string GlobalResources::readRequiredStringAttribute(pugi::xml_node node, const char* attribute)
+std::string GlobalResources::readRequiredStringAttribute(pugi::xml_node node, const char *attribute)
 {
-    if (node.attribute(attribute).empty()) {
+    if (node.attribute(attribute).empty())
+    {
         FATAL("Can not read node:" << node.path() << " " << attribute);
     }
     return node.attribute(attribute).as_string();
 }
 
-std::vector<std::string> GlobalResources::string_split(const std::string& str, const std::string& delim)
+std::vector<std::string> GlobalResources::string_split(const std::string &str, const std::string &delim)
 {
     std::vector<std::string> strings;
     auto start = 0U;
     auto end = str.find(delim);
-    while (end!=std::string::npos) {
-        strings.push_back(str.substr(start, end-start));
-        start = static_cast<unsigned int>(end+1);
+    while (end != std::string::npos)
+    {
+        strings.push_back(str.substr(start, end - start));
+        start = static_cast<unsigned int>(end + 1);
         end = str.find(delim, start);
     }
     strings.push_back(str.substr(start, end));
     return strings;
 }
 
-std::vector<int> GlobalResources::strs_to_ints(const std::vector<std::string>& strings)
+std::vector<int> GlobalResources::strs_to_ints(const std::vector<std::string> &strings)
 {
     std::vector<int> ints{};
-    for (auto& str: strings) {
+    for (auto &str : strings)
+    {
         ints.push_back(std::stoi(str));
     }
     return ints;
@@ -166,7 +178,8 @@ void GlobalResources::createRoutingTable()
         std::string word;
         int DIR;
         std::vector<int> v;
-        while(iss >> word) {
+        while (iss >> word)
+        {
             DIR = std::stoi(word);
             v.push_back(DIR);
         }
@@ -174,24 +187,26 @@ void GlobalResources::createRoutingTable()
         RoutingTable.push_back(v);
         cpt_line += 1;
     }
-    std::cout<<"Routing Table :"<< std::endl;
+    std::cout << "Routing Table :" << std::endl;
 
-    for(auto vec : RoutingTable)
+    for (auto vec : RoutingTable)
     {
-        for(auto x : vec)
-            std::cout<<x<<" , ";
+        for (auto x : vec)
+            std::cout << x << " , ";
         std::cout << std::endl;
     }
 }
 
-void GlobalResources::readConfigFile(const std::string& configPath)
+void GlobalResources::readConfigFile(const std::string &configPath)
 {
     pugi::xml_document doc;
 
     std::cout << "Reading simulator config: " << configPath << endl;
     struct stat buffer;
-    if (!stat (configPath.c_str(), &buffer) == 0)
-        cout << endl <<"ERROR: Config file not found, program will exit with exception" << endl << endl;
+    if (!stat(configPath.c_str(), &buffer) == 0)
+        cout << endl
+             << "ERROR: Config file not found, program will exit with exception" << endl
+             << endl;
     pugi::xml_parse_result result = doc.load_file(configPath.c_str());
     assert(result && "Failed to read simulator config file!");
 
@@ -204,15 +219,18 @@ void GlobalResources::readConfigFile(const std::string& configPath)
 
     //ROUTING TABLE
     pugi::xml_node Routing_node = doc.child("configuration").child("noc").child("routingTable");
-    if (Routing_node.child("routingTable_mode") != NULL){
+    if (Routing_node.child("routingTable_mode") != NULL)
+    {
         RoutingTable_mode = Routing_node.child("routingTable_mode").attribute("value").as_bool();
     }
-    else{
+    else
+    {
         RoutingTable_mode = 0;
     }
-    std::cout<<"Routing table mode: "<<RoutingTable_mode<<std::endl;
+    std::cout << "Routing table mode: " << RoutingTable_mode << std::endl;
 
-    if (RoutingTable_mode == 1){
+    if (RoutingTable_mode == 1)
+    {
         pugi::xml_node RTFile_node = Routing_node.child("routingTable_path");
         RoutingTable_file = readRequiredStringAttribute(RTFile_node, "value");
         createRoutingTable();
@@ -246,7 +264,8 @@ void GlobalResources::readConfigFile(const std::string& configPath)
     numberOfTrafficTypes = app_node.child("numberOfTrafficTypes").attribute("value").as_int();
 
     synthID_t syntheticPhaseID = 0;
-    for (pugi::xml_node phase_node : app_node.child("synthetic").children("phase")) {
+    for (pugi::xml_node phase_node : app_node.child("synthetic").children("phase"))
+    {
         std::string name = readRequiredStringAttribute(phase_node, "name");
         std::string distribution = readRequiredStringAttribute(phase_node, "distribution", "value");
         float injectionRate = readRequiredFloatAttribute(phase_node, "injectionRate", "value");
@@ -266,15 +285,16 @@ void GlobalResources::readConfigFile(const std::string& configPath)
         readAttributeIfExists(phase_node, "hotspot", "value", sp.hotspot);
 
         //set first start time after warmup to start of measurement
-        if (benchmark=="synthetic" && name!="warmup" &&
-                synthetic_start_measurement_time==-1) {
+        if (benchmark == "synthetic" && name != "warmup" &&
+            synthetic_start_measurement_time == -1)
+        {
             synthetic_start_measurement_time = sp.minStart;
         }
         syntheticPhases.push_back(sp);
     }
 }
 
-void GlobalResources::readNoCLayout(const std::string& nocPath)
+void GlobalResources::readNoCLayout(const std::string &nocPath)
 {
     std::cout << "Reading NoC layout: " << nocPath << endl;
     assert(access(nocPath.c_str(), F_OK) != -1);
@@ -284,27 +304,32 @@ void GlobalResources::readNoCLayout(const std::string& nocPath)
 
     pugi::xml_node noc_node = doc.child("network-on-chip");
     bufferDepthType = noc_node.child("bufferDepthType").attribute("value").as_string();
-    if (!bufferDepthType.empty() && (bufferDepthType!="single" && bufferDepthType!="perVC")) {
+    if (!bufferDepthType.empty() && (bufferDepthType != "single" && bufferDepthType != "perVC"))
+    {
         FATAL("The value of bufferDepthType in your network file should be either 'single' or 'perVC'!");
     }
 
     readNodeTypes(noc_node);
     readNodes(noc_node);
     readConnections(noc_node);
-    if (!RoutingTable_mode){
+    if (!RoutingTable_mode)
+    {
         fillDirInfoOfNodeConn();
     }
-    else{
+    else
+    {
         fillDirInfoOfNodeConn_DM();
     }
 }
 
-void GlobalResources::readNodeTypes(const pugi::xml_node& noc_node)
+void GlobalResources::readNodeTypes(const pugi::xml_node &noc_node)
 {
-    for (pugi::xml_node node : noc_node.child("nodeTypes").children("nodeType")) {
+    for (pugi::xml_node node : noc_node.child("nodeTypes").children("nodeType"))
+    {
         dataTypeID_t typeID = node.attribute("id").as_int();
         std::string model = node.child("model").attribute("value").as_string();
-        if (model.empty()) cout << "Model not set properly for nodeType with id " << typeID << endl;
+        if (model.empty())
+            cout << "Model not set properly for nodeType with id " << typeID << endl;
         std::string routing = node.child("routing").attribute("value").as_string();
         std::string selection = node.child("selection").attribute("value").as_string();
         int clkDelay = node.child("clockDelay").attribute("value").as_int();
@@ -314,11 +339,12 @@ void GlobalResources::readNodeTypes(const pugi::xml_node& noc_node)
     }
 }
 
-void GlobalResources::readNodes(const pugi::xml_node& noc_node)
+void GlobalResources::readNodes(const pugi::xml_node &noc_node)
 {
-    for (pugi::xml_node xmlnode : noc_node.child("nodes").children("node")) {
+    for (pugi::xml_node xmlnode : noc_node.child("nodes").children("node"))
+    {
         nodeID_t nodeID = xmlnode.attribute("id").as_int();
-        std::string name = "node_"+std::to_string(nodeID);
+        std::string name = "node_" + std::to_string(nodeID);
         float x = xmlnode.child("xPos").attribute("value").as_float();
         float y = xmlnode.child("yPos").attribute("value").as_float();
         float z = xmlnode.child("zPos").attribute("value").as_float();
@@ -347,46 +373,60 @@ void GlobalResources::sortNodesPositions()
 
 void GlobalResources::fillDirInfoOfNodeConn()
 {
-    for (Node& node : nodes) {
+    for (Node &node : nodes)
+    {
         //check for common directions
         Vec3D<float> distance{};
-        for (int connectedNodeID : node.connectedNodes) {
+        for (int connectedNodeID : node.connectedNodes)
+        {
             Node connectedNode = nodes.at(connectedNodeID);
-            distance = node.pos-connectedNode.pos;
+            distance = node.pos - connectedNode.pos;
             connID_t matching_conn = node.getConnWithNode(connectedNode);
             DIR::TYPE dir{};
-            if (distance.isZero()) { //no axis differs
+            if (distance.isZero())
+            { //no axis differs
                 dir = DIR::Local;
             }
-            else { //one axis differs
-                if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().xPositions.size() > 2 && (node.pos.x == 0. && connectedNode.pos.x == 1. && node.pos.y == connectedNode.pos.y)){
+            else
+            { //one axis differs
+                if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().xPositions.size() > 2 && (node.pos.x == 0. && connectedNode.pos.x == 1. && node.pos.y == connectedNode.pos.y))
+                {
                     dir = DIR::West;
                 }
-                else if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().xPositions.size() > 2 && (node.pos.x == 1. && connectedNode.pos.x == 0. && node.pos.y == connectedNode.pos.y)){
+                else if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().xPositions.size() > 2 && (node.pos.x == 1. && connectedNode.pos.x == 0. && node.pos.y == connectedNode.pos.y))
+                {
                     dir = DIR::East;
                 }
-                else if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().yPositions.size() > 2 && (node.pos.y == 0. && connectedNode.pos.y == 1. && node.pos.x == connectedNode.pos.x)){
+                else if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().yPositions.size() > 2 && (node.pos.y == 0. && connectedNode.pos.y == 1. && node.pos.x == connectedNode.pos.x))
+                {
                     dir = DIR::South;
                 }
-                else if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().yPositions.size() > 2 && (node.pos.y == 1. && connectedNode.pos.y == 0. && node.pos.x == connectedNode.pos.x)){
+                else if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().yPositions.size() > 2 && (node.pos.y == 1. && connectedNode.pos.y == 0. && node.pos.x == connectedNode.pos.x))
+                {
                     dir = DIR::North;
                 }
-                else if (distance.x>0) {
+                else if (distance.x > 0)
+                {
                     dir = DIR::West;
                 }
-                else if (distance.x<0) {
+                else if (distance.x < 0)
+                {
                     dir = DIR::East;
                 }
-                else if (distance.y<0) {
+                else if (distance.y < 0)
+                {
                     dir = DIR::North;
                 }
-                else if (distance.y>0) {
+                else if (distance.y > 0)
+                {
                     dir = DIR::South;
                 }
-                else if (distance.z<0) {
+                else if (distance.z < 0)
+                {
                     dir = DIR::Up;
                 }
-                else if (distance.z>0) {
+                else if (distance.z > 0)
+                {
                     dir = DIR::Down;
                 }
             }
@@ -396,14 +436,13 @@ void GlobalResources::fillDirInfoOfNodeConn()
     }
 }
 
-
 // My fillDirInfoOfNodeConn() function. Rely on Direction_Mat.txt file
 
 void GlobalResources::fillDirInfoOfNodeConn_DM()
 {
     std::cout << "Start filling direction of nodes \n";
 
-    std::vector<std::vector<int>> directions_mat ;
+    std::vector<std::vector<int>> directions_mat;
     std::ifstream infile(DirectionMat_file);
     std::string line;
 
@@ -415,7 +454,8 @@ void GlobalResources::fillDirInfoOfNodeConn_DM()
         std::string word;
         int DIR;
         std::vector<int> v;
-        while(iss >> word) {
+        while (iss >> word)
+        {
             DIR = std::stoi(word);
             v.push_back(DIR);
         }
@@ -423,53 +463,70 @@ void GlobalResources::fillDirInfoOfNodeConn_DM()
         directions_mat.push_back(v);
         cpt_line += 1;
     }
-    std::cout<<"Direction Matrix :"<< std::endl;
+    std::cout << "Direction Matrix :" << std::endl;
 
-    for(auto vec : directions_mat)
+    for (auto vec : directions_mat)
     {
-        for(auto x : vec)
-            std::cout<<x<<" , ";
+        for (auto x : vec)
+            std::cout << x << " , ";
         std::cout << std::endl;
     }
 
-    for (Node& node : nodes) {
-        for (int connectedNodeID : node.connectedNodes) {
+    for (Node &node : nodes)
+    {
+        for (int connectedNodeID : node.connectedNodes)
+        {
             Node connectedNode = nodes.at(connectedNodeID);
             Vec3D<float> distance{};
-            distance = node.pos-connectedNode.pos;
+            distance = node.pos - connectedNode.pos;
             connID_t matching_conn = node.getConnWithNode(connectedNode);
             DIR::TYPE dir{};
             int d;
-            if (distance.isZero()) { //no axis differs
+            if (distance.isZero())
+            { //no axis differs
                 dir = DIR::Local;
             }
-            else {
+            else
+            {
                 d = directions_mat[node.id][connectedNode.id];
-                if (d == -1){
+                if (d == -1)
+                {
                     std::cout << "error, no direction found \n";
                 }
-                else{
-                    if (d==1){
+                else
+                {
+                    if (d == 1)
+                    {
                         dir = DIR::East;
                     }
-                    else{
-                        if (d==2){
+                    else
+                    {
+                        if (d == 2)
+                        {
                             dir = DIR::West;
                         }
-                        else{
-                            if (d==3){
+                        else
+                        {
+                            if (d == 3)
+                            {
                                 dir = DIR::North;
                             }
-                            else{
-                                if (d==4){
+                            else
+                            {
+                                if (d == 4)
+                                {
                                     dir = DIR::South;
                                 }
-                                else{
-                                    if (d==5){
+                                else
+                                {
+                                    if (d == 5)
+                                    {
                                         dir = DIR::Up;
                                     }
-                                    else{
-                                        if (d==6){
+                                    else
+                                    {
+                                        if (d == 6)
+                                        {
                                             dir = DIR::Down;
                                         }
                                     }
@@ -483,29 +540,32 @@ void GlobalResources::fillDirInfoOfNodeConn_DM()
             node.setDirOfConn(matching_conn, dir);
         }
     }
-
 }
 
-void GlobalResources::readConnections(const pugi::xml_node& noc_node)
+void GlobalResources::readConnections(const pugi::xml_node &noc_node)
 {
-    for (pugi::xml_node xml_con : noc_node.child("connections").children("con")) {
+    for (pugi::xml_node xml_con : noc_node.child("connections").children("con"))
+    {
         connID_t connID = xml_con.attribute("id").as_int();
         std::vector<nodeID_t> nodesOfConnection{};
         std::vector<int> vcsCount{};
         std::vector<int> buffersDepth{};
         std::vector<std::vector<int>> buffersDepths{};
 
-        for (pugi::xml_node xml_port : xml_con.child("ports").children("port")) {
+        for (pugi::xml_node xml_port : xml_con.child("ports").children("port"))
+        {
             nodeID_t connectedNodeID = xml_port.child("node").attribute("value").as_int();
             nodesOfConnection.push_back(connectedNodeID);
             int vcCount = xml_port.child("vcCount").attribute("value").as_int();
             vcsCount.push_back(vcCount);
             buffersDepth.push_back(xml_port.child("bufferDepth").attribute("value").as_int());
 
-            if (bufferDepthType=="perVC") {
+            if (bufferDepthType == "perVC")
+            {
                 std::string str_vec = xml_port.child("buffersDepths").attribute("value").as_string();
                 std::vector<std::string> strings = string_split(str_vec, ",");
-                if (strings.size()!=vcCount) {
+                if (strings.size() != vcCount)
+                {
                     FATAL("The buffersDepths size is not equal to vcCount!");
                 }
                 std::vector<int> bd = strs_to_ints(strings);
@@ -520,14 +580,16 @@ void GlobalResources::readConnections(const pugi::xml_node& noc_node)
         int width = xml_con.child("width").attribute("value").as_int();
 
         Connection con = Connection(connID, nodesOfConnection, vcsCount, buffersDepth, buffersDepths, length, width,
-                depth);
+                                    depth);
 
         int nodesSize = nodesOfConnection.size();
         con.bufferUtilization.resize(nodesSize);
-        for (nodeID_t nID : con.nodes) {
+        for (nodeID_t nID : con.nodes)
+        {
             // Now that we know the nodes of each connection, we should reflect this info to the nodes themselves.
-            for (nodeID_t dstNodeID: con.nodes) {
-                if (nID!=dstNodeID)
+            for (nodeID_t dstNodeID : con.nodes)
+            {
+                if (nID != dstNodeID)
                     nodes.at(nID).connectedNodes.push_back(dstNodeID);
             }
             nodes.at(nID).connections.push_back(con.id);
@@ -537,13 +599,13 @@ void GlobalResources::readConnections(const pugi::xml_node& noc_node)
     }
 }
 
-void GlobalResources::readTaskAndMapFiles(const std::string& taskFilePath, const std::string& mappingFilePath)
+void GlobalResources::readTaskAndMapFiles(const std::string &taskFilePath, const std::string &mappingFilePath)
 {
     std::map<taskID_t, nodeID_t> bindings = readMappingFile(mappingFilePath);
     readTaskFile(taskFilePath, bindings);
 }
 
-std::map<taskID_t, nodeID_t> GlobalResources::readMappingFile(const std::string& mappingFilePath)
+std::map<taskID_t, nodeID_t> GlobalResources::readMappingFile(const std::string &mappingFilePath)
 {
     std::cout << "Reading Mapping config: " << mappingFilePath << endl;
     pugi::xml_document doc;
@@ -552,7 +614,8 @@ std::map<taskID_t, nodeID_t> GlobalResources::readMappingFile(const std::string&
 
     pugi::xml_node map_node = doc.child("map");
     std::map<taskID_t, nodeID_t> bindings;
-    for (pugi::xml_node bind_node : map_node.children("bind")) {
+    for (pugi::xml_node bind_node : map_node.children("bind"))
+    {
         int taskID = readRequiredIntAttribute(bind_node, "task", "value");
         int nodeID = readRequiredIntAttribute(bind_node, "node", "value");
         bindings.emplace(taskID, nodeID);
@@ -560,7 +623,7 @@ std::map<taskID_t, nodeID_t> GlobalResources::readMappingFile(const std::string&
     return bindings;
 }
 
-void GlobalResources::readTaskFile(const std::string& taskFilePath, const std::map<int, int>& bindings)
+void GlobalResources::readTaskFile(const std::string &taskFilePath, const std::map<int, int> &bindings)
 {
     //TODO the bindings vector was used to get the destination node and not task, of a current task.. keep it?
     std::cout << "Reading Data config: " << taskFilePath << endl;
@@ -571,13 +634,15 @@ void GlobalResources::readTaskFile(const std::string& taskFilePath, const std::m
 
     // Read Data Types
     numberOfTrafficTypes = static_cast<int>(data_node.child("dataTypes").select_nodes("dataType").size());
-    for (pugi::xml_node type_node : data_node.child("dataTypes").children("dataType")) {
+    for (pugi::xml_node type_node : data_node.child("dataTypes").children("dataType"))
+    {
         dataTypeID_t dataTypeID = readRequiredIntAttribute(type_node, "id");
         std::string name = readRequiredStringAttribute(type_node, "name", "value");
         dataTypes.emplace_back(dataTypeID, name);
     }
     // Read Tasks
-    for (pugi::xml_node task_node : data_node.child("tasks").children("task")) {
+    for (pugi::xml_node task_node : data_node.child("tasks").children("task"))
+    {
         taskID_t taskID = task_node.attribute("id").as_int();
         Task task = Task{taskID, bindings.at(taskID)};
         readAttributeIfExists(task_node, "start", "min", task.minStart);
@@ -589,7 +654,8 @@ void GlobalResources::readTaskFile(const std::string& taskFilePath, const std::m
 
         // Read Requirements
         std::vector<DataRequirement> requirements{};
-        for (pugi::xml_node requirement_node : task_node.child("requires").children("requirement")) {
+        for (pugi::xml_node requirement_node : task_node.child("requires").children("requirement"))
+        {
             dataReqID_t reqID = readRequiredIntAttribute(requirement_node, "id");
             dataTypeID_t typeID = readRequiredIntAttribute(requirement_node, "type", "value");
             DataRequirement req = DataRequirement{reqID, typeID};
@@ -601,11 +667,13 @@ void GlobalResources::readTaskFile(const std::string& taskFilePath, const std::m
 
         // Read Destinations
         std::vector<DataSendPossibility> possibilities{};
-        for (pugi::xml_node generate_node : task_node.child("generates").children("possibility")) {
+        for (pugi::xml_node generate_node : task_node.child("generates").children("possibility"))
+        {
             possID_t possID = readRequiredIntAttribute(generate_node, "id");
             float probability = readRequiredFloatAttribute(generate_node, "probability", "value");
             std::vector<DataDestination> destinations{};
-            for (pugi::xml_node destination_node : generate_node.child("destinations").children("destination")) {
+            for (pugi::xml_node destination_node : generate_node.child("destinations").children("destination"))
+            {
                 dataDestID_t dataDestID = readRequiredIntAttribute(destination_node, "id");
                 dataTypeID_t typeID = readRequiredIntAttribute(destination_node, "type", "value");
                 taskID_t destTaskID = readRequiredIntAttribute(destination_node, "task", "value");
@@ -629,11 +697,12 @@ void GlobalResources::readTaskFile(const std::string& taskFilePath, const std::m
     }
 }
 
-std::vector<Node*> GlobalResources::getNodesByPos(const Vec3D<float>& pos)
+std::vector<Node *> GlobalResources::getNodesByPos(const Vec3D<float> &pos)
 {
-    std::vector<Node*> matching_nodes{};
-    for (auto& node:nodes)
-        if (node.getNodeByPos(pos)) {
+    std::vector<Node *> matching_nodes{};
+    for (auto &node : nodes)
+        if (node.getNodeByPos(pos))
+        {
             matching_nodes.push_back(&node);
         }
     return matching_nodes;

--- a/simulator/src/utils/GlobalResources.cpp
+++ b/simulator/src/utils/GlobalResources.cpp
@@ -248,9 +248,6 @@ void GlobalResources::readConfigFile(const std::string &configPath)
     routingVerticalThreshold = noc_node.child("routingVerticalThreshold").attribute("value").as_float();
     Vdd = noc_node.child("Vdd").attribute("value").as_float();
 
-    topology = noc_node.child_value("topology");
-    routingCircular = std::set<std::string>({std::string("torus"), std::string("ring")}).count(topology);
-
     //APPLICATION
     pugi::xml_node app_node = doc.child("configuration").child("application");
     benchmark = app_node.child_value("benchmark");
@@ -308,6 +305,10 @@ void GlobalResources::readNoCLayout(const std::string &nocPath)
     {
         FATAL("The value of bufferDepthType in your network file should be either 'single' or 'perVC'!");
     }
+
+    // topology
+    topology = noc_node.child_value("topology");
+    routingCircular = std::set<std::string>({std::string("torus"), std::string("ring")}).count(topology);
 
     readNodeTypes(noc_node);
     readNodes(noc_node);

--- a/simulator/src/utils/GlobalResources.cpp
+++ b/simulator/src/utils/GlobalResources.cpp
@@ -389,19 +389,19 @@ void GlobalResources::fillDirInfoOfNodeConn()
             }
             else
             { //one axis differs
-                if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().xPositions.size() > 2 && (node.pos.x == 0. && connectedNode.pos.x == 1. && node.pos.y == connectedNode.pos.y))
+                if (routingCircular && xPositions.size() > 2 && (node.pos.x == 0. && connectedNode.pos.x == 1. && node.pos.y == connectedNode.pos.y))
                 {
                     dir = DIR::West;
                 }
-                else if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().xPositions.size() > 2 && (node.pos.x == 1. && connectedNode.pos.x == 0. && node.pos.y == connectedNode.pos.y))
+                else if (routingCircular && xPositions.size() > 2 && (node.pos.x == 1. && connectedNode.pos.x == 0. && node.pos.y == connectedNode.pos.y))
                 {
                     dir = DIR::East;
                 }
-                else if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().yPositions.size() > 2 && (node.pos.y == 0. && connectedNode.pos.y == 1. && node.pos.x == connectedNode.pos.x))
+                else if (routingCircular && yPositions.size() > 2 && (node.pos.y == 0. && connectedNode.pos.y == 1. && node.pos.x == connectedNode.pos.x))
                 {
                     dir = DIR::South;
                 }
-                else if (GlobalResources::getInstance().routingCircular && GlobalResources::getInstance().yPositions.size() > 2 && (node.pos.y == 1. && connectedNode.pos.y == 0. && node.pos.x == connectedNode.pos.x))
+                else if (routingCircular && yPositions.size() > 2 && (node.pos.y == 1. && connectedNode.pos.y == 0. && node.pos.x == connectedNode.pos.x))
                 {
                     dir = DIR::North;
                 }

--- a/simulator/src/utils/GlobalResources.h
+++ b/simulator/src/utils/GlobalResources.h
@@ -46,6 +46,13 @@ public:
     std::vector<float> xPositions;
     std::vector<float> yPositions;
     std::vector<float> zPositions;
+    float z_step;
+    std::vector<float> y_step;
+    std::vector<float> x_step;
+    std::vector<float> z_range;
+    std::vector<std::vector<float>> y_range;
+    std::vector<std::vector<float>> x_range;
+    std::map<Vec3D<float>, Vec3D<int>> norm_to_coord; // normalised coordinate to integer coorinate
     //General
     int simulation_time;
     bool outputToFile;

--- a/simulator/src/utils/GlobalResources.h
+++ b/simulator/src/utils/GlobalResources.h
@@ -51,8 +51,6 @@ public:
     std::string outputFileName;
     std::string outputDirectory;
     std::string noc_file;
-    std::string topology;         // store the topology of the network (mesh, torus, ring)
-    bool routingCircular = false; // decide whether the routing algorithm is routed in a circular way (for torus and ring)
     int flitsPerPacket = 0;
     int bitWidth = 32;
     float routingVerticalThreshold = 1.0f;
@@ -86,6 +84,8 @@ public:
     std::vector<Task> tasks;
     std::vector<DataType> dataTypes;
     std::vector<SyntheticPhase> syntheticPhases;
+    std::string topology;         // store the topology of the network (mesh, torus, ring)
+    bool routingCircular = false; // decide whether the routing algorithm is routed in a circular way (for torus and ring)
 
     long long rd_seed;
     std::mt19937_64 *rand;

--- a/simulator/src/utils/GlobalResources.h
+++ b/simulator/src/utils/GlobalResources.h
@@ -37,7 +37,8 @@
 #include <fstream>
 #include <iostream>
 
-class GlobalResources {
+class GlobalResources
+{
 
 public:
     std::vector<float> xPositions;
@@ -59,7 +60,7 @@ public:
     std::string bufferDepthType;
     std::string RoutingTable_file;
     bool RoutingTable_mode;
-    std::vector <std::vector<int> > RoutingTable;
+    std::vector<std::vector<int>> RoutingTable;
     std::string DirectionMat_file;
     //Application
     std::string benchmark;
@@ -73,7 +74,7 @@ public:
     std::map<nodeID_t, int> netraceNodeToTask;
     std::map<int, nodeID_t> netraceTaskToNode;
     bool netrace2Dor3Dmode = true; // true == 2D
-    int netraceVerbosity = 2; // 2==all, 1 == base, 0 == none
+    int netraceVerbosity = 2;      // 2==all, 1 == base, 0 == none
 #endif
     bool isUniform;
     int numberOfTrafficTypes;
@@ -87,37 +88,37 @@ public:
     std::vector<SyntheticPhase> syntheticPhases;
 
     long long rd_seed;
-    std::mt19937_64* rand;
+    std::mt19937_64 *rand;
 
     //debug
     bool routingDebugMode = false;
 
-    static GlobalResources& getInstance();
+    static GlobalResources &getInstance();
 
     int getRandomIntBetween(int, int);
 
     float getRandomFloatBetween(float, float);
 
-    void readConfigFile(const std::string& configPath);
+    void readConfigFile(const std::string &configPath);
 
-    void readNoCLayout(const std::string& nocPath);
+    void readNoCLayout(const std::string &nocPath);
 
-    void readTaskAndMapFiles(const std::string& taskFilePath, const std::string& mappingFilePath);
+    void readTaskAndMapFiles(const std::string &taskFilePath, const std::string &mappingFilePath);
 
-    std::vector<Node*> getNodesByPos(const Vec3D<float>& pos);
+    std::vector<Node *> getNodesByPos(const Vec3D<float> &pos);
 
 private:
     GlobalResources();
 
     ~GlobalResources();
 
-    std::vector<std::string> string_split(const std::string& str, const std::string& delim);
+    std::vector<std::string> string_split(const std::string &str, const std::string &delim);
 
-    std::vector<int> strs_to_ints(const std::vector<std::string>& strings);
+    std::vector<int> strs_to_ints(const std::vector<std::string> &strings);
 
-    void readNodeTypes(const pugi::xml_node& noc_node);
+    void readNodeTypes(const pugi::xml_node &noc_node);
 
-    void readNodes(const pugi::xml_node& noc_node);
+    void readNodes(const pugi::xml_node &noc_node);
 
     void sortNodesPositions();
 
@@ -125,27 +126,27 @@ private:
 
     void fillDirInfoOfNodeConn_DM();
 
-    void readConnections(const pugi::xml_node& noc_node);
+    void readConnections(const pugi::xml_node &noc_node);
 
-    void readAttributeIfExists(pugi::xml_node, const char*, const char*, int&);
+    void readAttributeIfExists(pugi::xml_node, const char *, const char *, int &);
 
     void readAttributeIfExists(pugi::xml_node, const char *, int &);
 
-    void readTaskFile(const std::string& taskFilePath, const std::map<int, int>& bindings);
+    void readTaskFile(const std::string &taskFilePath, const std::map<int, int> &bindings);
 
-    std::map<int, int> readMappingFile(const std::string& mappingFilePath);
+    std::map<int, int> readMappingFile(const std::string &mappingFilePath);
 
-    std::string readRequiredStringAttribute(pugi::xml_node, const char*, const char*);
+    std::string readRequiredStringAttribute(pugi::xml_node, const char *, const char *);
 
-    std::string readRequiredStringAttribute(pugi::xml_node, const char*);
+    std::string readRequiredStringAttribute(pugi::xml_node, const char *);
 
-    int readRequiredIntAttribute(pugi::xml_node, const char*, const char*);
+    int readRequiredIntAttribute(pugi::xml_node, const char *, const char *);
 
-    int readRequiredIntAttribute(pugi::xml_node, const char*);
+    int readRequiredIntAttribute(pugi::xml_node, const char *);
 
-    float readRequiredFloatAttribute(pugi::xml_node, const char*, const char*);
+    float readRequiredFloatAttribute(pugi::xml_node, const char *, const char *);
 
-    float readRequiredFloatAttribute(pugi::xml_node, const char*);
+    float readRequiredFloatAttribute(pugi::xml_node, const char *);
 
     void createRoutingTable();
 };

--- a/simulator/src/utils/GlobalResources.h
+++ b/simulator/src/utils/GlobalResources.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include <set>
 #include <map>
 #include <unistd.h>
@@ -35,6 +36,7 @@
 #include <cmath>
 #include <list>
 #include <fstream>
+#include <sstream>
 #include <iostream>
 
 class GlobalResources
@@ -71,7 +73,6 @@ public:
 #ifdef ENABLE_NETRACE
     std::map<nodeID_t, int> netraceNodeToTask;
     std::map<int, nodeID_t> netraceTaskToNode;
-    bool netrace2Dor3Dmode = true; // true == 2D
     int netraceVerbosity = 2;      // 2==all, 1 == base, 0 == none
 #endif
     bool isUniform;


### PR DESCRIPTION
- The commits are 54f289f, 205249d, ea46140. The rest of the commits are same as the new pull request #95 because I want to test the 3d torus for netrace.
- This pull request requires this feature to work: https://github.com/jmjos/ratatoskr-tools/commit/f74cc140f8d4c81e68d6ec20aeb87bffe11c9ace & https://github.com/jmjos/ratatoskr-tools/pull/5#issue-598723170
- Tested on urand 4x4, 8x8x1, 8x8x2, 8x4x2, 4x4x4. All pass
- Tested on netrace 8x8x1, 8x8x2, 8x4x2, 4x4x4. All pass.

Q&A:
1. What is the goal?
	- The goal is to retrieve the xyz step value to compare the distances of 2 directions
2. Why not only xyz value is enough? (checkout this commit https://github.com/jmjos/ratatoskr-tools/commit/3febaf574aa1b61494551366cca4dbf8040a8c3d line309-315) 
	- To prevent the rounding different between c++ and python
3. Why add xyz-range? (https://github.com/jmjos/ratatoskr-tools/commit/f74cc140f8d4c81e68d6ec20aeb87bffe11c9ace)
	- to create a mapping from normalized coordinate to integer coordinate
		- `map<Vec3D<float>,Vec3D<int>> norm_to_coord`
		- The `norm_to_coord` is to know the z-position of the node (integer), then this value is required for the xy-step value of each layer
	- For future usage xyz-range value such as inhomogeneous NoC, it is recommended to add it in network.xml

I know it is not nice to increase the complexity of network.xml, but after I have considered it, I would suggest to add it in network.xml.